### PR TITLE
[sccp] ansi not only indicators have reverse itu order for pc/ssn

### DIFF
--- a/test/otc_sccp_codec_tests.erl
+++ b/test/otc_sccp_codec_tests.erl
@@ -337,8 +337,8 @@ calling_party_address_itu() ->
 called_party_address_ansi() ->
     <<16#0C, %% Length
       2#1_0_0010_1_1, %% AddressIndicator (NI, GTI=0010, PC, SSN)
-      16#654321:24, %% PC
       16#07, %% SSN
+      16#654321:24, %% PC
       16#0E, %% TT
       16#11, 16#32, 16#54, 16#76, 16#98, 16#00>>.
 calling_party_address_ansi() ->


### PR DESCRIPTION
according to ANSI, the order is
GTI, PCI, SSNI, SSN, PC, GT

and according to ITU-T the full order is
GTI, SSNI, PCI, PC, SSN, GT


See Figure 4 and 4A of ATIS1000112.3 and Figure 4 and 5 of ITU-T Q.713.